### PR TITLE
Let bridged tap interfaces inherit bridge's MTU

### DIFF
--- a/kvm-ifup-custom.in
+++ b/kvm-ifup-custom.in
@@ -65,7 +65,7 @@ if [ "X$MODE" == "Xrouted" ]; then
     fi
   done
 elif [ "X$MODE" == "Xbridged" ]; then
-  $IP_CMD link set dev $INTERFACE up
+  $IP_CMD link set dev $INTERFACE mtu $(</sys/class/net/${BRIDGE}/mtu) up
   $BRCTL addif $BRIDGE $INTERFACE
   # many people have bridged networks that are not added to gnt-network
   # use this hack to apply configuration to these as well


### PR DESCRIPTION
This commit makes kvm-ifup-custom bring up tap interfaces with
MTU value equal to the one of their bridge.

MTU is set before adding the tap interface to the bridge, since
Linux bridge will dynamically adapt its MTU to the lowest MTU
value of its members ports.

This commit enables jumbo frames, MTU > 1500, for tap interfaces,
as long as their bridge MTU is configured as such.